### PR TITLE
FIX: Getting the CL's warehouse instead of the VE's to check the stock

### DIFF
--- a/react/components/ProductAvailabilityWrapper.tsx
+++ b/react/components/ProductAvailabilityWrapper.tsx
@@ -127,15 +127,12 @@ function ProductAvailabilityWrapper({
             .then(response => response.json())
             // eslint-disable-next-line no-console
             .then(user => {
-                console.log(user[0])
-
                 if (user[0].agente === "VE" || user[0].agente === "VC" || user[0].agente === "CO") {
                     fetch(`https://${window.location.hostname}/_v/user/${clientId}`,
                         {
                             credentials: 'include'
                         })
                         .then(response => {
-                            console.log(response)
                             return response.json()
                         })
                         .then(client => {

--- a/react/components/ProductAvailabilityWrapper.tsx
+++ b/react/components/ProductAvailabilityWrapper.tsx
@@ -103,6 +103,7 @@ function ProductAvailabilityWrapper({
     const [userId, setUserId] = useState<string>('');
     const [warehouse, setWarehouse] = useState<string>('');
     const [isSeller, setIsSeller] = useState<boolean>(false);
+    const [clientId, setClientId] = useState<string>('');
     const seller = getFirstAvailableSeller(
         productContextValue?.selectedItem?.sellers
     )
@@ -126,14 +127,27 @@ function ProductAvailabilityWrapper({
             .then(response => response.json())
             // eslint-disable-next-line no-console
             .then(user => {
-                if(user[0].agente === "VE" || user[0].agente === "VC" || user[0].agente === "CO") {
-                    setWarehouse(user[0].sucursal)
-                    setIsSeller(true);
+                console.log(user[0])
+
+                if (user[0].agente === "VE" || user[0].agente === "VC" || user[0].agente === "CO") {
+                    fetch(`https://${window.location.hostname}/_v/user/${clientId}`,
+                        {
+                            credentials: 'include'
+                        })
+                        .then(response => {
+                            console.log(response)
+                            return response.json()
+                        })
+                        .then(client => {
+                            setWarehouse(client[0].sucursal)
+                            setIsSeller(true);
+                        })
                 }
             })
     }
     useEffect(() => {
         if (typeof window !== "undefined") {
+            setClientId(session?.data?.session?.namespaces?.profile?.id?.value)
             setUserId(session?.data?.session?.namespaces?.authentication?.storeUserId?.value)
         }
     }, [session])


### PR DESCRIPTION
We created a new state "clientId" to save the client's id in order to get their warehouse if the user (whose id is saved in "userId") is a VE. Once the correct warehouse is set, the stock checking process is the same.

Repository: https://github.com/strlla/product-availability-gallery

Evidence: comparing the product-availability stock according to the VE's and CL's warehouse while doing the TLK
https://watch.screencastify.com/v/4Ri8TSoH9hAXUGwPcWoz

In case of any doubts or suggestions, please let us know.